### PR TITLE
refactor: Commander args parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,42 @@ This is a clone of my solution, as iterated through their cli and tests.
  - [ ] fix eslint to get 2 space indent 
  - [ ] Improve helpers, esp fn names, to clarify read vs write vs file load
  - [ ] Actually handle REF-delta, not error and abandon rest of packfile
- - [ ] Convert main and sloppy cmdline args to Commander
+ - [x] Convert main and sloppy cmdline args to Commander
  - [ ] Remove console.logs from test runs without debugger
+ - [ ] Improve Markdown skills 😅
 
+---
+## Example 1
+1. Use real git to get the sha of HEAD.
+```
+git log -2
+> commit bb832fb99979762dc876fe60e7fb549cc4e7f79b (HEAD, origin/main, origin/HEAD, main)
+```
+2. Inspect contents of that commit blob.
+```
+npm start -- cat-file bb832fb99979762dc876fe60e7fb549cc4e7f79b
+> tree 9c3cc82b8715651709e08060c4d497a406f7e571
+> parent d58487d7b464324ac8144502c67af24262548287
+> author Ryan Belev <ryan.belev@gmail.com> 1741365655 -0800
+> committer Ryan Belev <ryan.belev@gmail.com> 1741365655 -0800
+> 
+> docs: ack console.logs to be removed
+```
+3. Inspect contents of the commit's tree blob.
+```
+npm start -- ls-tree 9c3cc82b8715651709e08060c4d497a406f7e571
+> 40000  tree       ceaa32026e6ed5b62e49602907acf6e84a371313 .codecrafters
+> 100644 file       176a458f94e0ea5272ce67c36bf30b6be9caf623 .gitattributes
+> 100644 file       9cf6fffa3721899fd47ac27afd5e6051e18e142e .gitignore
+> 100644 file       635718467cd09d7d85c827f4b6f077738b46fc20 README.md
+> 40000  tree       03fae9ded5c4331cd0fb20b7d04924d8c32dacb3 app
+> 100644 file       a263216b54b95a17266ce03393005611a43213eb codecrafters.yml
+> 100644 file       8b331f9a7014ded1e4992a122fd27b81c4778c20 eslint.config.mjs
+> 100644 file       41de4d883ba6512616b94e4138c3059c17d1b6ce package-lock.json
+> 100644 file       9c7092fc4bad00dfcda47d994fd633d93c459f04 package.json
+> 100644 file       815a959bbde1933c8d1c9d2e090cb17f69835b0d tsconfig.json
+> 100755 executable fcc2fd5faa528f966cbaa64c267df03332d890ed your_program.sh
+```
 ---
 [![progress-banner](https://backend.codecrafters.io/progress/git/8d79512b-ae04-4119-a028-33eecab83985)](https://app.codecrafters.io/users/codecrafters-bot?r=2qF)
 

--- a/app/commands/commit-tree.ts
+++ b/app/commands/commit-tree.ts
@@ -1,13 +1,9 @@
-import { commit, object, type Sha } from '../helpers/index.ts';
+import { commit, object, type CommitTreeParams, type Sha } from '../helpers/index.ts';
 
-export async function commitTree(args: string[]): Promise<Sha> {
+export async function commitTree(args:  CommitTreeParams): Promise<Sha> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [_cmd, treeSha, _p, parentSha, _m, message] = args;
-    const tree = commit.formatCommitTree({
-        treeSha,
-        parents: parentSha,
-        message,
-    });
+    // const [_cmd, treeSha, _p, parentSha, _m, message] = args;
+    const tree = commit.formatCommitTree(args);
 
     return await object.writeObjectContents(tree);
 }

--- a/app/commands/index.ts
+++ b/app/commands/index.ts
@@ -6,6 +6,7 @@ export * as init from './init.ts';
 export * as ls_tree from './ls-tree.ts';
 export * as write_tree from './write-tree.ts';
 
+// TODO: Utilize this list in Commander initialization for TypeScript completeness?
 export const Commands = {
     Init: 'init',
     CatFile: 'cat-file',

--- a/app/commands/ls-tree.ts
+++ b/app/commands/ls-tree.ts
@@ -1,8 +1,8 @@
 import { object, trees, type LsTree, type Sha } from '../helpers/index.ts';
 
-export async function readLsTree(args: string[]): Promise<LsTree> {
+export async function readLsTree(treeSha: string): Promise<LsTree> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [_ls, _nameOnly, treeSha] = args;
+    // const [_ls, _nameOnly, treeSha] = args;
     const file = await object.loadObjectFile(treeSha as Sha);
 
     return trees.parseTreeFile(file);

--- a/app/helpers/index.ts
+++ b/app/helpers/index.ts
@@ -5,5 +5,6 @@ export * as sha from './sha.ts';
 export * as trees from './trees.ts';
 export * as pack from './pack.ts';
 
+export type { CommitTreeParams } from './commit.ts';
 export type { Sha } from './sha.ts';
 export type { LsTree } from './trees.ts';

--- a/app/helpers/pack.ts
+++ b/app/helpers/pack.ts
@@ -25,14 +25,14 @@ export async function breakdownPack(pack: ArrayBuffer): Promise<PackItem[]> {
     const version = Buffer.from(pack, headerStart + 4, 4).readUInt32BE(0);
     const itemsContained = Buffer.from(pack, headerStart + 8, 4).readUint32BE();
 
-    console.log(`breakdownPack: ${header} v${version} #${itemsContained} len:${pack.byteLength}`);
+    // console.log(`breakdownPack: ${header} v${version} #${itemsContained} len:${pack.byteLength}`);
 
     let cursor = headerStart + 12;
     const entries: PackItem[] = [];
     for (let i = 0; i < itemsContained; i += 1) {
 
         const pointer = extractPackEntryTypeAndSize(pack, cursor);
-        console.log(`breakdownPack: ${pointer.type} ${pointer.size} ${pointer.position}/${pack.byteLength}`)
+        // console.log(`breakdownPack: ${pointer.type} ${pointer.size} ${pointer.position}/${pack.byteLength}`)
         try {
             const entry = await getNextEntry(pack, pointer);
             entries[i] = { content: entry.content, type: pointer.type };
@@ -90,7 +90,7 @@ async function getNextEntry(buffer: ArrayBuffer, pointer: EntryPointer): Promise
         //   Neither pulling a 20 byte sha or looking for \0 delimiting a name worked.
         const nullByte = zipContent.indexOf('\0');
         const baseObjectName = zipContent.subarray(0, nullByte).toString('ascii');
-        console.log(`getNextEntry: got ${nullByte}->'${baseObjectName}'`);
+        // console.log(`getNextEntry: got ${nullByte}->'${baseObjectName}'`);
         bytesConsumed += nullByte + 1;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "codecrafters-git-clone",
       "version": "1.0.0",
+      "dependencies": {
+        "commander": "^13.1.0"
+      },
       "devDependencies": {
         "@stylistic/eslint-plugin-ts": "^4.2.0",
         "@types/node": "^22.13.9",
@@ -636,6 +639,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "start": "node --experimental-strip-types ./app/main.ts",
+    "start": "NODE_NO_WARNINGS=1 NODE_OPTIONS=--experimental-strip-types node ./app/main.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "cat-file": "npm run start -- cat-file 14225c42a03630c8528007ea24fca972b9a37f8d"
   },
@@ -20,5 +20,8 @@
     "eslint": "^9.21.0",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.0"
+  },
+  "dependencies": {
+    "commander": "^13.1.0"
   }
 }


### PR DESCRIPTION
The difference between Commander's `.command(<args>, <description>)` and `.command(<args>).description(<description>)` was a real gotcha. The former looks for a named executable file, whereas the latter utilizes the `.action`.